### PR TITLE
Add corpus write actions

### DIFF
--- a/src/facades/definitions.ts
+++ b/src/facades/definitions.ts
@@ -425,13 +425,16 @@ export const proFacades: FacadeSpec[] = [
 
   {
     name: 'corpus',
-    description: 'Pattern and playbook search across codebase. search to find code patterns, implementation examples, or playbooks by natural language query. status to check index freshness. Use before implementing something to find existing patterns to follow. Actions: search, status',
-    compactDescription: 'Search patterns and playbooks',
+    description: 'Shared knowledge base: patterns, playbooks, and field notes. search to find existing solutions before implementing; add_pattern for reusable solutions (id must be PREFIX-NNNN); add_field_note for lessons learned; add_playbook for step-by-step guides. status to check corpus availability. All writes are no-overwrite — they fail if the file already exists. Actions: search, status, add_pattern, add_field_note, add_playbook',
+    compactDescription: 'Search and contribute to shared knowledge base',
     microEligible: false,
     tier: 'pro',
     actions: {
       search: 'corpus_search',
       status: 'corpus_status',
+      add_pattern: 'corpus_add_pattern',
+      add_field_note: 'corpus_add_field_note',
+      add_playbook: 'corpus_add_playbook',
     },
   },
 

--- a/src/tools/corpus.ts
+++ b/src/tools/corpus.ts
@@ -5,10 +5,13 @@
 // Enables cross-project knowledge sharing without submodules.
 // ============================================================================
 
-import { readdir, readFile } from 'fs/promises';
-import { join, basename } from 'path';
+import { readdir, readFile, writeFile } from 'fs/promises';
+import { join, basename, resolve, relative } from 'path';
 import { homedir } from 'os';
+import { existsSync } from 'fs';
 import { log } from '../config.js';
+import { ensureDir } from '../dataRoot.js';
+import { emitCreateProvenance } from './provenance.js';
 
 // ============================================================================
 // Types
@@ -36,6 +39,42 @@ export interface CorpusSearchResult {
   query: string;
   searched: number;
   corpus_path: string;
+}
+
+export interface AddPatternInput {
+  id: string;
+  title: string;
+  content: string;
+  category?: string;
+  status?: string;
+  severity?: string;
+  source?: string;
+  owner?: string;
+  tags?: string[];
+}
+
+export interface AddFieldNoteInput {
+  title: string;
+  content: string;
+  source?: string;
+  owner?: string;
+  status?: string;
+  tags?: string[];
+}
+
+export interface AddPlaybookInput {
+  title: string;
+  content: string;
+  owner?: string;
+  status?: string;
+  tags?: string[];
+}
+
+export interface CorpusWriteResult {
+  id: string;
+  path: string;
+  absolute_path: string;
+  title: string;
 }
 
 // ============================================================================
@@ -240,4 +279,257 @@ export async function corpusExists(): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// ============================================================================
+// Write Helpers
+// ============================================================================
+
+const PATTERN_ID_RE = /^[A-Z]+-\d{3,}$/;
+
+/**
+ * Slugify text for use in filenames.
+ * Lowercases, replaces non-alphanumeric with dashes, trims dashes, max 80 chars.
+ */
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+}
+
+/**
+ * Build YAML frontmatter block from key-value pairs.
+ * Handles arrays (tags) as YAML lists.
+ */
+function buildFrontmatter(fields: Record<string, string | string[] | undefined>): string {
+  const lines: string[] = ['---'];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - ${item}`);
+      }
+    } else {
+      lines.push(`${key}: ${value}`);
+    }
+  }
+  lines.push('---');
+  return lines.join('\n');
+}
+
+/**
+ * Validate that a target path is within CORPUS_PATH (prevents directory traversal).
+ */
+function validateCorpusWritePath(targetPath: string): void {
+  const resolved = resolve(targetPath);
+  const corpusResolved = resolve(CORPUS_PATH);
+  if (!resolved.startsWith(corpusResolved + '/')) {
+    throw new Error(
+      `Path traversal rejected: target "${relative(corpusResolved, resolved)}" escapes corpus root`
+    );
+  }
+}
+
+/**
+ * Validate that a category string has no traversal characters.
+ */
+function validateCategory(category: string): void {
+  if (/[\/\\.]/.test(category)) {
+    throw new Error(
+      `Invalid category "${category}": must not contain slashes, backslashes, or dots`
+    );
+  }
+}
+
+// ============================================================================
+// Write Functions
+// ============================================================================
+
+/**
+ * Add a pattern to decibel-corpus.
+ * Writes to primitives/patterns/{category?}/{id}-{slug}.md
+ */
+export async function addPattern(input: AddPatternInput): Promise<CorpusWriteResult> {
+  if (!await corpusExists()) {
+    throw new Error(
+      `Corpus not found at ${CORPUS_PATH}. ` +
+      'Clone decibel-corpus or set DECIBEL_CORPUS_PATH.'
+    );
+  }
+
+  if (!PATTERN_ID_RE.test(input.id)) {
+    throw new Error(
+      `Invalid pattern id "${input.id}": must match PREFIX-NNNN format (e.g., DBS-0004)`
+    );
+  }
+
+  const slug = slugify(input.title);
+  const filename = `${input.id}-${slug}.md`;
+
+  let targetDir = join(CORPUS_PATH, TYPE_PATHS['pattern']);
+  if (input.category) {
+    validateCategory(input.category);
+    targetDir = join(targetDir, input.category);
+  }
+  ensureDir(targetDir);
+
+  const targetPath = join(targetDir, filename);
+  validateCorpusWritePath(targetPath);
+
+  if (existsSync(targetPath)) {
+    throw new Error(
+      `Pattern already exists at ${relative(CORPUS_PATH, targetPath)}. ` +
+      'Will not overwrite — edit the file directly if an update is needed.'
+    );
+  }
+
+  const frontmatter = buildFrontmatter({
+    id: input.id,
+    title: input.title,
+    status: input.status || 'draft',
+    severity: input.severity,
+    category: input.category,
+    source: input.source,
+    owner: input.owner,
+    tags: input.tags,
+    created: new Date().toISOString().slice(0, 10),
+  });
+
+  const fileContent = `${frontmatter}\n\n# ${input.title}\n\n${input.content}\n`;
+  await writeFile(targetPath, fileContent, 'utf-8');
+
+  const relPath = relative(CORPUS_PATH, targetPath);
+  log(`Corpus: Added pattern ${input.id} at ${relPath}`);
+
+  // Best-effort provenance
+  try {
+    await emitCreateProvenance(`corpus:pattern:${input.id}`, fileContent, `Added pattern ${input.id}: ${input.title}`);
+  } catch {
+    // No project context — that's fine for corpus
+  }
+
+  return {
+    id: input.id,
+    path: relPath,
+    absolute_path: targetPath,
+    title: input.title,
+  };
+}
+
+/**
+ * Add a field note to decibel-corpus.
+ * Writes to field-notes/YYYY-MM-DD-{slug}.md
+ */
+export async function addFieldNote(input: AddFieldNoteInput): Promise<CorpusWriteResult> {
+  if (!await corpusExists()) {
+    throw new Error(
+      `Corpus not found at ${CORPUS_PATH}. ` +
+      'Clone decibel-corpus or set DECIBEL_CORPUS_PATH.'
+    );
+  }
+
+  const slug = slugify(input.title);
+  const date = new Date().toISOString().slice(0, 10);
+  const filename = `${date}-${slug}.md`;
+
+  const targetDir = join(CORPUS_PATH, TYPE_PATHS['field-note']);
+  ensureDir(targetDir);
+
+  const targetPath = join(targetDir, filename);
+  validateCorpusWritePath(targetPath);
+
+  if (existsSync(targetPath)) {
+    throw new Error(
+      `Field note already exists at ${relative(CORPUS_PATH, targetPath)}. ` +
+      'Will not overwrite — edit the file directly if an update is needed.'
+    );
+  }
+
+  const frontmatter = buildFrontmatter({
+    title: input.title,
+    status: input.status || 'draft',
+    source: input.source,
+    owner: input.owner,
+    tags: input.tags,
+    created: date,
+  });
+
+  const fileContent = `${frontmatter}\n\n# ${input.title}\n\n${input.content}\n`;
+  await writeFile(targetPath, fileContent, 'utf-8');
+
+  const relPath = relative(CORPUS_PATH, targetPath);
+  const id = basename(filename, '.md');
+  log(`Corpus: Added field note at ${relPath}`);
+
+  try {
+    await emitCreateProvenance(`corpus:field-note:${id}`, fileContent, `Added field note: ${input.title}`);
+  } catch {
+    // No project context — that's fine for corpus
+  }
+
+  return {
+    id,
+    path: relPath,
+    absolute_path: targetPath,
+    title: input.title,
+  };
+}
+
+/**
+ * Add a playbook to decibel-corpus.
+ * Writes to playbooks/{slug}.md
+ */
+export async function addPlaybook(input: AddPlaybookInput): Promise<CorpusWriteResult> {
+  if (!await corpusExists()) {
+    throw new Error(
+      `Corpus not found at ${CORPUS_PATH}. ` +
+      'Clone decibel-corpus or set DECIBEL_CORPUS_PATH.'
+    );
+  }
+
+  const slug = slugify(input.title);
+  const filename = `${slug}.md`;
+
+  const targetDir = join(CORPUS_PATH, TYPE_PATHS['playbook']);
+  ensureDir(targetDir);
+
+  const targetPath = join(targetDir, filename);
+  validateCorpusWritePath(targetPath);
+
+  if (existsSync(targetPath)) {
+    throw new Error(
+      `Playbook already exists at ${relative(CORPUS_PATH, targetPath)}. ` +
+      'Will not overwrite — edit the file directly if an update is needed.'
+    );
+  }
+
+  const frontmatter = buildFrontmatter({
+    title: input.title,
+    status: input.status || 'draft',
+    owner: input.owner,
+    tags: input.tags,
+    created: new Date().toISOString().slice(0, 10),
+  });
+
+  const fileContent = `${frontmatter}\n\n# ${input.title}\n\n${input.content}\n`;
+  await writeFile(targetPath, fileContent, 'utf-8');
+
+  const relPath = relative(CORPUS_PATH, targetPath);
+  log(`Corpus: Added playbook at ${relPath}`);
+
+  try {
+    await emitCreateProvenance(`corpus:playbook:${slug}`, fileContent, `Added playbook: ${input.title}`);
+  } catch {
+    // No project context — that's fine for corpus
+  }
+
+  return {
+    id: slug,
+    path: relPath,
+    absolute_path: targetPath,
+    title: input.title,
+  };
 }

--- a/src/tools/corpus/index.ts
+++ b/src/tools/corpus/index.ts
@@ -13,6 +13,12 @@ import {
   CorpusContentType,
   getCorpusPath,
   corpusExists,
+  addPattern,
+  AddPatternInput,
+  addFieldNote,
+  AddFieldNoteInput,
+  addPlaybook,
+  AddPlaybookInput,
 } from '../corpus.js';
 
 // ============================================================================
@@ -116,10 +122,195 @@ export const corpusStatusTool: ToolSpec = {
 };
 
 // ============================================================================
+// Corpus Add Pattern Tool
+// ============================================================================
+
+export const corpusAddPatternTool: ToolSpec = {
+  definition: {
+    name: 'corpus_add_pattern',
+    description: `Add a reusable pattern to decibel-corpus. Patterns are named solutions to recurring problems (e.g., "advisory lock for idempotency", "exponential backoff with jitter"). The id must match PREFIX-NNNN format (e.g., DBS-0004). Will not overwrite existing files.`,
+    annotations: {
+      title: 'Add Corpus Pattern',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: {
+          type: 'string',
+          description: 'Pattern identifier in PREFIX-NNNN format (e.g., DBS-0004, A11Y-0001)',
+        },
+        title: {
+          type: 'string',
+          description: 'Human-readable title (e.g., "Advisory Lock for Idempotent Mutations")',
+        },
+        content: {
+          type: 'string',
+          description: 'Markdown body — problem statement, solution, code examples, trade-offs',
+        },
+        category: {
+          type: 'string',
+          description: 'Optional subdirectory within primitives/patterns/ (e.g., "concurrency", "auth")',
+        },
+        status: {
+          type: 'string',
+          description: 'Pattern maturity: draft, reviewed, canonical (default: draft)',
+        },
+        severity: {
+          type: 'string',
+          description: 'Impact level if the pattern is not followed (e.g., "high", "critical")',
+        },
+        source: {
+          type: 'string',
+          description: 'Where this pattern was discovered (e.g., "EPIC-0032", "incident-2026-03")',
+        },
+        owner: {
+          type: 'string',
+          description: 'Who authored or is responsible for this pattern',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Searchable tags (e.g., ["postgres", "concurrency", "idempotency"])',
+        },
+      },
+      required: ['id', 'title', 'content'],
+    },
+  },
+  handler: async (args) => {
+    try {
+      const input = args as AddPatternInput;
+      requireFields(input, 'id', 'title', 'content');
+      const result = await addPattern(input);
+      return toolSuccess(result);
+    } catch (err) {
+      return toolError(err instanceof Error ? err.message : String(err));
+    }
+  },
+};
+
+// ============================================================================
+// Corpus Add Field Note Tool
+// ============================================================================
+
+export const corpusAddFieldNoteTool: ToolSpec = {
+  definition: {
+    name: 'corpus_add_field_note',
+    description: `Add a field note to decibel-corpus. Field notes capture lessons learned, gotchas, and observations from real work — things that aren't patterns yet but are worth remembering. Filename is auto-generated as YYYY-MM-DD-{slug}.md. Will not overwrite existing files.`,
+    annotations: {
+      title: 'Add Corpus Field Note',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+          description: 'Descriptive title (e.g., "Supabase RLS gotcha with service role key")',
+        },
+        content: {
+          type: 'string',
+          description: 'Markdown body — what happened, what was learned, any code examples',
+        },
+        source: {
+          type: 'string',
+          description: 'Context where this was observed (e.g., "EPIC-0032", "senken deploy 2026-03")',
+        },
+        owner: {
+          type: 'string',
+          description: 'Who captured this note',
+        },
+        status: {
+          type: 'string',
+          description: 'Note maturity: draft, reviewed, promoted (default: draft)',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Searchable tags (e.g., ["supabase", "rls", "auth"])',
+        },
+      },
+      required: ['title', 'content'],
+    },
+  },
+  handler: async (args) => {
+    try {
+      const input = args as AddFieldNoteInput;
+      requireFields(input, 'title', 'content');
+      const result = await addFieldNote(input);
+      return toolSuccess(result);
+    } catch (err) {
+      return toolError(err instanceof Error ? err.message : String(err));
+    }
+  },
+};
+
+// ============================================================================
+// Corpus Add Playbook Tool
+// ============================================================================
+
+export const corpusAddPlaybookTool: ToolSpec = {
+  definition: {
+    name: 'corpus_add_playbook',
+    description: `Add a playbook to decibel-corpus. Playbooks are step-by-step guides for specific operations (e.g., "deploy senken to production", "rotate Supabase keys", "onboard new MCP module"). Filename is auto-generated as {slug}.md. Will not overwrite existing files.`,
+    annotations: {
+      title: 'Add Corpus Playbook',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+          description: 'Playbook title (e.g., "Deploy Senken to Production")',
+        },
+        content: {
+          type: 'string',
+          description: 'Markdown body — numbered steps, prerequisites, rollback procedures',
+        },
+        owner: {
+          type: 'string',
+          description: 'Who authored this playbook',
+        },
+        status: {
+          type: 'string',
+          description: 'Playbook maturity: draft, reviewed, canonical (default: draft)',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Searchable tags (e.g., ["deployment", "senken", "production"])',
+        },
+      },
+      required: ['title', 'content'],
+    },
+  },
+  handler: async (args) => {
+    try {
+      const input = args as AddPlaybookInput;
+      requireFields(input, 'title', 'content');
+      const result = await addPlaybook(input);
+      return toolSuccess(result);
+    } catch (err) {
+      return toolError(err instanceof Error ? err.message : String(err));
+    }
+  },
+};
+
+// ============================================================================
 // Export All Tools
 // ============================================================================
 
 export const corpusTools: ToolSpec[] = [
   corpusSearchTool,
   corpusStatusTool,
+  corpusAddPatternTool,
+  corpusAddFieldNoteTool,
+  corpusAddPlaybookTool,
 ];


### PR DESCRIPTION
## Summary

- Adds 3 write actions to the corpus facade: `add_pattern`, `add_field_note`, `add_playbook`
- Resolves friction logged during EPIC-0032 planning — agents had to bypass tool abstraction to contribute to decibel-corpus
- Each action writes frontmatter+markdown, validates paths against traversal, refuses to overwrite existing files, and emits best-effort provenance

## Test plan

- [ ] `npm run build` — clean compile
- [ ] Call `corpus add_pattern` with test data — verify file at `primitives/patterns/{id}-{slug}.md`
- [ ] Call `corpus add_field_note` — verify file at `field-notes/YYYY-MM-DD-{slug}.md`
- [ ] Call `corpus add_playbook` — verify file at `playbooks/{slug}.md`
- [ ] Round-trip: add a pattern, then `corpus search` for it — confirm it appears
- [ ] Path traversal: `category: "../../etc"` — verify rejection
- [ ] Overwrite guard: add same pattern twice — verify error on second attempt
- [ ] Missing corpus: unset `DECIBEL_CORPUS_PATH` and remove default path — verify actionable error

🤖 Generated with [Claude Code](https://claude.com/claude-code)